### PR TITLE
Make the screenshot button behave like the original

### DIFF
--- a/script/screenshotPageActionButton.uc.js
+++ b/script/screenshotPageActionButton.uc.js
@@ -78,7 +78,7 @@
          *                 is "true" if we're currently taking a screenshot, "false" if not.
          */
         observe(sub, top, data) {
-            this.setButtonState(data === "true"); // disable the button while we're already taking a screenshot, just like the toolbar button.
+            //this.setButtonState(data === "true"); // uncomment to disable the button while we're already taking a screenshot.
         },
         /**
          * Set the "shooting" property on the button node.


### PR DESCRIPTION
The original screenshot button toggled the screenshot interface when it was pressed, while this script disables the button while the screenshot interface is open.

I just commented out the code that disables the button, so that if someone wants to revert it, they have the option to do that.

Comparision recordings:
[The original button](https://oliverparoczai.dev/files/fforiginalscreenshotbutton.gif) vs [The reimplemented button](https://oliverparoczai.dev/files/ffreimpscreenshotbutton.gif)