### PR TITLE
Few ideas for fluentRevealNavbar.uc.js

### DIFF
--- a/JS/fluentRevealNavbar.uc.js
+++ b/JS/fluentRevealNavbar.uc.js
@@ -173,6 +173,7 @@
         area = el.querySelector(".toolbarbutton-text");
       }
 
+      // previous pointerEvents check may break the effect in FF 115
       //if (el.disabled || areaStyle.pointerEvents == "none") {
       if (el.disabled) {
         return this.clearEffect(area);

--- a/JS/fluentRevealNavbar.uc.js
+++ b/JS/fluentRevealNavbar.uc.js
@@ -85,8 +85,11 @@
      */
     handleEvent(e) {
       /// filter out mouse events which are too far from toolbar to cause any actual redraw
-      /// value is {gradientSize} + some additional padding to make sure effect clears out properly
-      if (this._options.filterDy && e.clientY > this._options.gradientSize + 20) return;
+      /// value is {gradientSize} + some additional padding to make sure effect fully clears out
+      if (this._options.filterDy && e.clientY > this._options.gradientSize + 25) {
+        if (this.someEffectsApplied) this.clearEffectsForAll();
+        return;
+      }
       
       requestAnimationFrame(time => {
         switch (e.type) {
@@ -264,6 +267,17 @@
     clearEffect(el) {
       this._options.is_pressed = false;
       el.style.removeProperty("background-image");
+    }
+
+    /**
+    * invoked once when {filterDy} option enabled, and cursor leaves the interactive area
+    */
+    clearEffectsForAll() {
+      console.log('clear all effects');
+      this.someEffectsApplied = false;
+      this.toolbarButtons.forEach(button =>
+        this.clearEffect(button)
+      );
     }
   }
 

--- a/JS/fluentRevealNavbar.uc.js
+++ b/JS/fluentRevealNavbar.uc.js
@@ -163,6 +163,11 @@
           el.querySelector(".toolbarbutton-icon");
       if (!area) area = el;
 
+      // don't apply effect to focused url bar
+      if (this._options.includeUrlBar && el.id == 'urlbar-background' && window.gURLBar.focused) {
+        return this.clearEffect(area);
+      }
+
       let areaStyle = getComputedStyle(area);
       if (
         areaStyle.display == "none" ||

--- a/JS/fluentRevealNavbar.uc.js
+++ b/JS/fluentRevealNavbar.uc.js
@@ -24,6 +24,9 @@
 
       // whether to show an additional light burst when clicking an element. (not recommended)
       clickEffect: false,
+
+      // looks for all toolbar buttons only once on script startup — reduces system load, but requires browser restart if toolbar buttons were changed
+      cacheButtons: true,
     };
 
     // instantiate the handler for a given window
@@ -38,13 +41,15 @@
 
     // get all the toolbar buttons in the navbar, in iterable form
     get toolbarButtons() {
-      let buttons = Array.from(
-        gNavToolbox.querySelectorAll(".toolbarbutton-1")
-      );
-      if (this._options.includeBookmarks) {
-        buttons = buttons.concat(
-          Array.from(this.placesToolbarItems.querySelectorAll(".bookmark-item"))
+      if (!this.buttons || this._options.cacheButtons == false) {
+        let buttons = Array.from(
+          gNavToolbox.querySelectorAll(".toolbarbutton-1")
         );
+        if (this._options.includeBookmarks) {
+          buttons = buttons.concat(
+            Array.from(this.placesToolbarItems.querySelectorAll(".bookmark-item"))
+          );
+        }
       }
       return buttons;
     }

--- a/JS/fluentRevealNavbar.uc.js
+++ b/JS/fluentRevealNavbar.uc.js
@@ -17,7 +17,10 @@
       includeBookmarks: true,
 
       // the color of the gradient. default is sort of a faint baby blue. you may prefer just white, e.g. hsla(0, 0%, 100%, 0.05)
-      lightColor: "hsla(224, 100%, 80%, 0.15)",
+      // lightColor: "hsla(224, 100%, 80%, 0.15)",
+
+      // the color of the gradient. default is the browser's color of navbar button's hover 
+      lightColor: "var(--button-hover-bgcolor)",
 
       // how wide the radial gradient is.
       gradientSize: 50,

--- a/JS/fluentRevealNavbar.uc.js
+++ b/JS/fluentRevealNavbar.uc.js
@@ -31,12 +31,12 @@
       // whether to show an additional light burst when clicking an element. (not recommended)
       clickEffect: false,
 
-      // don't process mouse movements greater than {gradientSize}px from top of the screen, in order to reduce system load
+      // don't process mouse movements greater than {gradientSize}px from top of the screen, in order to reduce system load.
       // disable if you modified the ui to have toolbar buttons on different side of the screen (left, right or bottom)
       filterDy: true,
 
       // looks for all toolbar buttons only once on script startup — reduces system load, but requires browser restart if toolbar buttons were changed
-      cacheButtons: true,
+      cacheButtons: false,
     };
 
     // store cached navbar buttons

--- a/JS/fluentRevealNavbar.uc.js
+++ b/JS/fluentRevealNavbar.uc.js
@@ -149,7 +149,8 @@
         area = el.querySelector(".toolbarbutton-text");
       }
 
-      if (el.disabled || areaStyle.pointerEvents == "none") {
+      //if (el.disabled || areaStyle.pointerEvents == "none") {
+      if (el.disabled) {
         return this.clearEffect(area);
       }
 

--- a/JS/fluentRevealNavbar.uc.js
+++ b/JS/fluentRevealNavbar.uc.js
@@ -84,7 +84,9 @@
      * @param {object} e (event)
      */
     handleEvent(e) {
-      if (this._options.filterDy && e.clientY > this._options.gradientSize) return;
+      /// filter out mouse events which are too far from toolbar to cause any actual redraw
+      /// value is {gradientSize} + some additional padding to make sure effect clears out properly
+      if (this._options.filterDy && e.clientY > this._options.gradientSize + 20) return;
       
       requestAnimationFrame(time => {
         switch (e.type) {

--- a/JS/fluentRevealNavbar.uc.js
+++ b/JS/fluentRevealNavbar.uc.js
@@ -33,6 +33,9 @@
       cacheButtons: true,
     };
 
+    // store cached navbar buttons
+    static buttons;
+
     // instantiate the handler for a given window
     constructor() {
       this._options = FluentRevealEffect.options;

--- a/JS/fluentRevealNavbar.uc.js
+++ b/JS/fluentRevealNavbar.uc.js
@@ -16,6 +16,9 @@
       // if true, show the effect on bookmarks on the toolbar
       includeBookmarks: true,
 
+      // if ture, show the effect on the urlbar as well
+      includeUrlBar: true,
+
       // the color of the gradient. default is sort of a faint baby blue. you may prefer just white, e.g. hsla(0, 0%, 100%, 0.05)
       // lightColor: "hsla(224, 100%, 80%, 0.15)",
 
@@ -52,16 +55,19 @@
     // get all the toolbar buttons in the navbar, in iterable form
     get toolbarButtons() {
       if (!this.buttons || this._options.cacheButtons == false) {
-        let buttons = Array.from(
+        this.buttons = Array.from(
           gNavToolbox.querySelectorAll(".toolbarbutton-1")
         );
+        if (this._options.includeUrlBar) {
+          this.buttons.push(gNavToolbox.querySelector("#urlbar-background"));
+        }
         if (this._options.includeBookmarks) {
-          buttons = buttons.concat(
+          this.buttons = this.buttons.concat(
             Array.from(this.placesToolbarItems.querySelectorAll(".bookmark-item"))
           );
         }
       }
-      return buttons;
+      return this.buttons;
     }
 
     get placesToolbarItems() {
@@ -156,6 +162,8 @@
         ? el
         : el.querySelector(".toolbarbutton-badge-stack") ||
           el.querySelector(".toolbarbutton-icon");
+      if (!area) area = el;
+
       let areaStyle = getComputedStyle(area);
       if (
         areaStyle.display == "none" ||

--- a/JS/fluentRevealNavbar.uc.js
+++ b/JS/fluentRevealNavbar.uc.js
@@ -88,7 +88,6 @@
       
       requestAnimationFrame(time => {
         switch (e.type) {
-          case "scroll":
           case "mousemove":
             if (this._options.clickEffect && this._options.is_pressed) {
               this.generateEffectsForAll(e, true);

--- a/JS/fluentRevealNavbar.uc.js
+++ b/JS/fluentRevealNavbar.uc.js
@@ -25,6 +25,10 @@
       // whether to show an additional light burst when clicking an element. (not recommended)
       clickEffect: false,
 
+      // don't process mouse movements greater than {gradientSize}px from top of the screen, in order to reduce system load
+      // disable if you modified the ui to have toolbar buttons on different side of the screen (left, right or bottom)
+      filterDy: true,
+
       // looks for all toolbar buttons only once on script startup — reduces system load, but requires browser restart if toolbar buttons were changed
       cacheButtons: true,
     };
@@ -68,6 +72,8 @@
      * @param {object} e (event)
      */
     handleEvent(e) {
+      if (this._options.filterDy && e.clientY > this._options.gradientSize) return;
+      
       requestAnimationFrame(time => {
         switch (e.type) {
           case "scroll":


### PR DESCRIPTION
This PR: 

- Removes check `pointerEvents=none` on navbar button, which resulted in script not working for me on FF 115  
- Changes default color of effect to browser's color of navbar button's color (--button-hover-bgcolor)
- Removes unused `scroll` event listener
- Adds new options: 
- - `filterDy`, which don't process mouse movements greater than {gradientSize}px from top of the screen, in order to reduce system load (default: true)
- - `cacheButtons`, which stores all toolbar buttons on script init and then reuses the list on each draw iteration (default: false)
- - `includeUrlBar`, which applies effect to url bar as well (when it's not focused) (default: true)

