### PR TITLE
fix: data URL not extracted in recent version of FF

### DIFF
--- a/JS/contextMenuMods.uc.js
+++ b/JS/contextMenuMods.uc.js
@@ -133,9 +133,10 @@ class ContextMenuMods {
         item.classList.add("menuitem-iconic", "searchmenuitem");
         item.setAttribute("engine-id", engine.id);
         item.setAttribute("label", engine.name);
-        let iconURL = engine.getIconURL(16);
-        iconURL.then((iconData) => {
-          item.style.setProperty("--engine-icon", `url('${iconData}')`);
+        engine.getIconURL(16).then(iconURL => {
+          if (iconURL) {
+            item.style.setProperty("--engine-icon", `url('${iconURL}')`);
+          }
         });
         docfrag.appendChild(item);
       }

--- a/JS/contextMenuMods.uc.js
+++ b/JS/contextMenuMods.uc.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name           Context Menu Mods
-// @version        1.0.2
+// @version        1.0.3
 // @author         aminomancer
 // @homepageURL    https://github.com/aminomancer/uc.css.js
 // @description    Add some new items to the main content area context menu.

--- a/JS/contextMenuMods.uc.js
+++ b/JS/contextMenuMods.uc.js
@@ -134,9 +134,9 @@ class ContextMenuMods {
         item.setAttribute("engine-id", engine.id);
         item.setAttribute("label", engine.name);
         let iconURL = engine.getIconURL(16);
-        if (iconURL) {
-          item.style.setProperty("--engine-icon", `url('${iconURL}')`);
-        }
+        iconURL.then((iconData) => {
+          item.style.setProperty("--engine-icon", `url('${iconData}')`);
+        });
         docfrag.appendChild(item);
       }
       event.target.appendChild(docfrag);


### PR DESCRIPTION
Search engine icons have been missing from the addon in recent FF. This commit fixes the problem.