### PR TITLE
Update tabThumbnailTooltip.uc.js for Firefox Nightly 141

### DIFF
--- a/JS/tabThumbnailTooltip.uc.js
+++ b/JS/tabThumbnailTooltip.uc.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name           Tab Thumbnail Tooltip
-// @version        1.0.7
+// @version        1.0.8
 // @author         aminomancer
 // @homepage       https://github.com/aminomancer/uc.css.js
 // @description    Show a large thumbnail image to preview tab content when hovering a tab.
@@ -8,7 +8,6 @@
 // @updateURL      https://cdn.jsdelivr.net/gh/aminomancer/uc.css.js@master/JS/tabThumbnailTooltip.uc.js
 // @license        This Source Code Form is subject to the terms of the Creative Commons Attribution-NonCommercial-ShareAlike International License, v. 4.0. If a copy of the CC BY-NC-SA 4.0 was not distributed with this file, You can obtain one at http://creativecommons.org/licenses/by-nc-sa/4.0/ or send a letter to Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.
 // ==/UserScript==
-
 class TabThumbnail {
   // user preferences. add these in about:config if you want them to persist
   // between script updates without having to reapply them.
@@ -80,8 +79,6 @@ class TabThumbnail {
   id="tabThumbTooltip"
   noautohide="true"
   orient="vertical"
-  onpopupshowing="ucTabThumbnail.onPopupShowing();"
-  onpopuphiding="ucTabThumbnail.onPopupHiding();"
   hide-thumbnail="true"
   style="visibility: collapse">
   <vbox id="tabThumbBox">
@@ -92,13 +89,17 @@ class TabThumbnail {
     <html:div id="tabThumbCanvas"></html:div>
   </vbox>
 </tooltip>`;
-    this.registerSheet();
-    document
-      .getElementById("mainPopupSet")
-      .appendChild(MozXULElement.parseXULToFragment(markup));
+  this.registerSheet();
+  const mainPopupSet = document.getElementById("mainPopupSet");
+  if (mainPopupSet) {
+    const tooltipElement = MozXULElement.parseXULToFragment(markup).firstChild;
+    tooltipElement.addEventListener('popupshowing', () => this.onPopupShowing());
+    tooltipElement.addEventListener('popuphiding', () => this.onPopupHiding());
+    mainPopupSet.appendChild(tooltipElement);
     gBrowser.tabContainer.tooltip = "tabThumbTooltip";
     addEventListener("unload", () => this.cancelTimer(), false);
   }
+}
   async onPopupShowing() {
     let ready = await this.showPreview();
     if (ready) {


### PR DESCRIPTION
This pull request fixes the tabThumbnailTooltip script in Firefox nightly 141, correcting the problem of the script being blocked by the content-security-policy in Firefox Nightly 141.
Closes #110 

![script-fix-1](https://github.com/user-attachments/assets/a82704b2-691c-4946-a02e-326ebdcd523e)
