### PR TITLE
Add search engine ordering in context menu

### DIFF
--- a/JS/contextMenuMods.uc.js
+++ b/JS/contextMenuMods.uc.js
@@ -116,9 +116,11 @@
               id: engine.id,
               name: engine.name,
               iconURL: await engine.getIconURL(16),
+              order: engine._metaData.order,
             });
           })
         );
+        this.engines.sort((a, b) => a.order - b.order);
         enginesLocked = false;
       };
 


### PR DESCRIPTION
Because search icons are fetched asynchronously, the resulting list isn't always in order. This orders the list according to the user's preferences.