### PR TITLE
Order search engines in context menu

### DIFF
--- a/JS/contextMenuMods.uc.js
+++ b/JS/contextMenuMods.uc.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name           Context Menu Mods
-// @version        1.1.1
+// @version        1.1.2
 // @author         aminomancer
 // @homepageURL    https://github.com/aminomancer/uc.css.js
 // @description    Add some new items to the main content area context menu.
@@ -116,9 +116,11 @@
               id: engine.id,
               name: engine.name,
               iconURL: await engine.getIconURL(16),
+              order: engine._metaData.order,
             });
           })
         );
+        this.engines.sort((a, b) => a.order - b.order);
         enginesLocked = false;
       };
 


### PR DESCRIPTION
Since icons are fetched asynchronously, the resulting list isn't always in order. This change makes sure that the search engines are sorted according to the user's settings.